### PR TITLE
Python-3-x-updates

### DIFF
--- a/tcli/command_parser.py
+++ b/tcli/command_parser.py
@@ -163,7 +163,7 @@ class CommandParser(dict):
   def InlineOnly(self):
     """Unregister all non-inline commands from parser."""
 
-    for command_name in [c for c in self.keys()]:
+    for command_name in [c for c in self]:
       if not self[command_name].inline:
         self.UnRegisterCommand(command_name)
 

--- a/tcli/inventory_base.py
+++ b/tcli/inventory_base.py
@@ -28,6 +28,7 @@ source specific support.
 import collections
 import re
 import threading
+import typing
 from absl import flags
 from absl import logging
 
@@ -152,9 +153,9 @@ class Inventory(object):
     def __init__(self):
       Inventory.Request.UID += 1
       self.uid = Inventory.Request.UID
-      self.target = None
-      self.command = None
-      self.mode = None
+      self.target = ''
+      self.command = ''
+      self.mode = ''
 
   def __init__(self, batch=False):
     """Initialise thread safe access to data to support async calls."""
@@ -164,7 +165,7 @@ class Inventory(object):
     # Each value is a dictionary of attribute/value pairs.
     # If we have already loaded the devices, don't do it again.
     if not hasattr(self, '_devices'):
-      self._devices = None
+      self._devices = {}
     # List of device names.
     self._device_list = None
     # Filters and exclusions added by this library.
@@ -367,7 +368,7 @@ class Inventory(object):
     if word == ' ':
       word = ''
     completer_list = []
-    for attrib in self.ATTRIBUTES:
+    for attrib in DEVICE_ATTRIBUTES:
       if attrib.startswith(word):
         completer_list.append(attrib)
     completer_list.sort()
@@ -571,7 +572,7 @@ class Inventory(object):
               re_match.append(re.compile(filter_item, re.IGNORECASE))
             else:
               re_match.append(re.compile(filter_item))
-          except sre_constants.error:
+          except re.error:
             raise ValueError('Argument regexp %r is invalid' % filter_item)
         else:
           if ignore_case:
@@ -614,7 +615,7 @@ class Inventory(object):
   # Methods related to managing and serving the device inventory.            #
   ############################################################################
 
-  def _GetDevices(self):
+  def _GetDevices(self) -> dict[str, typing.Tuple]:
     """Returns a dict of Device objects. Blocks until devices have loaded."""
 
     if self.batch and not self._devices:
@@ -629,7 +630,7 @@ class Inventory(object):
           'Device inventory data failed to load or no devices found.')
     return self._devices
 
-  def _GetDeviceList(self):
+  def _GetDeviceList(self) -> list[str]:
     """Returns a list of Device name."""
 
     # A value of 'None' means the list needs to be built first.

--- a/tcli/inventory_base.py
+++ b/tcli/inventory_base.py
@@ -181,7 +181,7 @@ class Inventory(object):
 
     # Filters and exclusions added by this library.
     logging.debug('Device attributes statically defined: "%s".',
-                  DEVICE_ATTRIBUTES.keys())
+                  DEVICE_ATTRIBUTES)
     for attr in DEVICE_ATTRIBUTES:
       if attr == 'flags':
         # TODO(harro): Add support for filtering on flag values.
@@ -495,7 +495,7 @@ class Inventory(object):
           # Warn user if literal is unknown, skip warning in batch mode
           # as it is less valuable in this context and would trigger a
           # re-retrieval of the inventory.
-          validate_list = self._GetDevices().keys()
+          validate_list = self._GetDevices()
 
         elif (attribute in DEVICE_ATTRIBUTES and
               DEVICE_ATTRIBUTES[attribute].valid_values):

--- a/tcli/inventory_csv.py
+++ b/tcli/inventory_csv.py
@@ -147,7 +147,7 @@ class Inventory(inventory_base.Inventory):
     # ...
     # }
     #
-    # So we built an OrderedDict of NamedTuples using the 'collections' library.
+    # So we built an ordered dict of NamedTuples (python 3.6)
     # We enforce 'device' as the header of the first column and 'flags' as
     # the header of an optional list in the last column.
 
@@ -175,7 +175,7 @@ class Inventory(inventory_base.Inventory):
     # pylint: disable=invalid-name
     Device = collections.namedtuple('Device', header_list)
     # pylint: enable=invalid-name
-    devices = collections.OrderedDict()
+    devices = {}
     # xreadlines would be better but not supported by StringIO for testing.
     for line in buf:
       # Support commented lines, provide '#' is first character of line.

--- a/tcli/inventory_csv_test.py
+++ b/tcli/inventory_csv_test.py
@@ -154,8 +154,7 @@ class UnitTestCSVInventory(unittest.TestCase):
     self.inv._devices = {
         'abc': dev_attr(pop='abc'),
         'xyz': dev_attr(pop='xyz'),
-        'bogus': dev_attr(pop='')
-        }
+        'bogus': dev_attr(pop='')}
     # Defaults
     self.assertEqual('Pop: ', self.inv._CmdFilter('pop', []))
     self.assertEqual('XPop: ', self.inv._CmdFilter('xpop', []))
@@ -221,9 +220,9 @@ class UnitTestCSVInventory(unittest.TestCase):
     d2 = Device(vendor='cisco', realm='prod', pop='xyz01', flags=[])
     d3 = Device(vendor='juniper', realm='lab', pop='abc01', flags=[])
     d4 = Device(vendor='juniper', realm='lab', pop='abc02', flags=[])
-    self.inv._devices = collections.OrderedDict([
-        ('device01', d1), ('device02', d2),
-        ('device03', d3), ('device04', d4)])
+    self.inv._devices = {
+        'device01': d1, 'device02': d2,
+        'device03': d3, 'device04': d4}
     self.inv._filters['targets'] = ''
     self.inv._filters['realm'] = ''
     self.inv._filters['vendor'] = ''

--- a/tcli/inventory_csv_test.py
+++ b/tcli/inventory_csv_test.py
@@ -114,7 +114,7 @@ class UnitTestCSVInventory(unittest.TestCase):
   def testFetchDevices(self):
     """Tests directly loading device inventory from CSV file."""
     self.inv._FetchDevices()
-    devices = self.inv.devices.keys()
+    devices = self.inv.devices
     self.assertCountEqual(['device_a', 'device_b', 'device_c'], devices)
 
   def testDeviceList(self):

--- a/tcli/tcli_lib.py
+++ b/tcli/tcli_lib.py
@@ -342,18 +342,18 @@ class TCLI(object):
     self.safemode = False
     self.verbose = False
     # Attributes with defaults set by flags.
-    self.color = None
+    self.color = True
     self.color_scheme = None
     self.display = None
     self.filter = None
-    self.linewrap = None
+    self.linewrap = False
     self.mode = None
     self.timeout = None
     # Buffers
-    self.log = None
-    self.logall = None
-    self.record = None
-    self.recordall = None
+    self.log = ''
+    self.logall = ''
+    self.record = ''
+    self.recordall = ''
     # Display values.
     self.system_color = ''
     self.title_color = ''

--- a/tcli/tcli_test.py
+++ b/tcli/tcli_test.py
@@ -180,23 +180,23 @@ class UnitTestTCLI(unittest.TestCase):
   def testCopy(self):
     # TODO(harro): Tests for extended commands?
     self.tcli_obj.buffers.Append('label', 'content')
-    self.tcli_obj.record = None
-    self.tcli_obj.inline_tcli = copy.copy(self.tcli_obj)
+    self.tcli_obj.record = ''
+    inline_tcli = copy.copy(self.tcli_obj)
     self.assertEqual('content', self.tcli_obj.buffers.GetBuffer('label'))
     self.assertFalse(self.tcli_obj.record)
     # Change parent.
     self.tcli_obj.buffers.Append('label', 'more')
     self.tcli_obj.record = 'label'
-    # Change child.
-    self.tcli_obj.inline_tcli.record = 'anotherlabel'
+    # Change copy.
+    inline_tcli.record = 'anotherlabel'
 
     # Test the parent.
     self.assertEqual('content\nmore', self.tcli_obj.buffers.GetBuffer('label'))
     self.assertEqual('label', self.tcli_obj.record)
     # Test the child.
     self.assertEqual('content\nmore',
-                     self.tcli_obj.inline_tcli.buffers.GetBuffer('label'))
-    self.assertEqual('anotherlabel', self.tcli_obj.inline_tcli.record)
+                     inline_tcli.buffers.GetBuffer('label'))
+    self.assertEqual('anotherlabel', inline_tcli.record)
 
   def testSetDefaults(self):
     """Tests setup of default commands from Flags."""
@@ -362,8 +362,8 @@ class UnitTestTCLI(unittest.TestCase):
 
     self.tcli_obj.display = 'raw'
     self.tcli_obj.inventory._devices = {
-        'device_1': collections.OrderedDict([('Vendor', 'Asterix')]),
-        'device_2': collections.OrderedDict([('Vendor', 'Asterix')]),
+        'device_1': {'Vendor', 'Asterix'},
+        'device_2': {'Vendor', 'Asterix'},
     }
 
     # Raw headers.

--- a/tcli/text_buffer.py
+++ b/tcli/text_buffer.py
@@ -55,4 +55,4 @@ class TextBuffer(object):
 
   def ListBuffers(self):
     """Returns list of buffers that exist (created and not cleared)."""
-    return ' '.join(sorted(self._buffers.keys()))
+    return ' '.join(sorted(self._buffers))


### PR DESCRIPTION
Remove call to keys on Dictionaries
Remove OrderedDict as standard Dict is insertion ordered from 3.6 onwards